### PR TITLE
Only search instances with the Name tag set.

### DIFF
--- a/lib/awsam/ec2.rb
+++ b/lib/awsam/ec2.rb
@@ -36,7 +36,8 @@ module Awsam
       ec2.describe_tags(:filters => {
                           "resource-type" => "instance"
                         }).each do |tag|
-        if tag[:value].downcase.include?(instance_id.downcase)
+        if tag[:key] == "Name" &&
+            tag[:value].downcase.include?(instance_id.downcase)
           results << tag
         end
       end


### PR DESCRIPTION
This permits other tags to be set on an instance without them matching the instance search. 