### PR TITLE
Only export environment with aenv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,20 @@ AWSAM supports both AWS' legacy [Java-based CLI tools](http://docs.aws.amazon.co
 
 ### Environment variables
 
-*AWS Account Manager* sets a variety of environment variables when
-selecting accounts and SSH keypairs. Some of these environment
-variables match the ones used by the Amazon EC2 CLI tools and some our
-unique to AWSAM. It is often convenient to use these environment
-variables in DevOPs scripts in place of hard-coded values -- allowing
-your scripts to be seamlessly used for staging and production
-environments simply by switching the active account with `aem`.
+*AWS Account Manager* will set a variety of environment variables when
+ you execute the `aenv` shell wrapper:
+
+    $ env | grep AMAZON_ACCESS
+    Exit 1
+    $ aenv env | grep AMAZON_ACCESS
+    AMAZON_ACCESS_KEY_ID=AK....
+
+Some of these environment variables match the ones used by the Amazon
+EC2 CLI tools and some our unique to AWSAM. It is often convenient to
+use these environment variables in DevOPs scripts in place of
+hard-coded values -- allowing your scripts to be seamlessly used for
+staging and production environments simply by switching the active
+account with `aem` and wrapping execution of the command with `aenv`.
 
 The environment variables set when selecting an account are:
 
@@ -62,6 +69,10 @@ set:
 
 * `AMAZON_SSH_KEY_NAME` - Name of the keypair.
 * `AMAZON_SSH_KEY_FILE` - Full path to the public key PEM file
+
+**NOTE:** As of version 0.2.0, these are no longer set in the shell
+  environment by default. You must run any command that requires AWS
+  access with the `aenv` wrapper.
 
 ### Updating
 
@@ -150,6 +161,16 @@ a default will place an asterisk next to the key name in the `aem
 list` output.
 
     $ aem key use --default my-key-name
+
+### aenv utility: wrap command execution with AWS environment
+
+The `aenv` utility will wrap execution of any command with the AWS
+environment variables matching the currently selected account. This
+allows you to securely propagate environment variables only to
+commands that should have access to the current environment. Just
+prefix your command execution with `aenv` like:
+
+    $ aenv aws s3 ls
 
 ### assh utility: SSH by instance ID
 

--- a/bashrc/rc.scr
+++ b/bashrc/rc.scr
@@ -316,6 +316,11 @@ function __aem_use()
 	echo "AWSAccessKeyId=${AWS_ACCESS_KEY_ID}"   >| ${CREDENTIALS_FILE}
 	echo "AWSSecretKey=${AWS_SECRET_ACCESS_KEY}" >> ${CREDENTIALS_FILE}
 
+	# We're done, so clear the environment. This protects against
+	# leaking AWS creds to other apps.
+	UNSET_ENV=$(raem --environ --account $ACCT --unset)
+	eval $UNSET_ENV
+
 	return 0
 }
 

--- a/bin/aenv
+++ b/bin/aenv
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Local Variables:
+# mode: sh
+# End:
+
+if [ $# -lt 1 ]; then
+	echo "Usage: aenv cmd [arg1 arg2 ...]"
+	exit 1
+fi
+
+if [ -z "$AWSAM_ACTIVE_ACCOUNT" ]; then
+	echo "Must pick an account first with `aem use <>`"
+	exit 1
+fi
+
+ENV=$(raem --environ --account $AWSAM_ACTIVE_ACCOUNT --export)
+eval $ENV
+
+exec "$@"

--- a/bin/raem
+++ b/bin/raem
@@ -103,6 +103,14 @@ optparse = OptionParser.new do|opts|
     $cmd = :environ_key
   end
 
+  opts.on('--export') do
+    $options[:set_export] = true
+  end
+
+  opts.on('--unset') do
+    $options[:unset_environ] = true
+  end
+
   opts.on('--init') do
     $cmd = :init
   end
@@ -176,7 +184,11 @@ when :environ
     end
   end
 
-  acct.print_environ
+  if $options[:unset_environ]
+    acct.print_unset_environ
+  else
+    acct.print_environ(!$options[:set_export].nil?)
+  end
 
 when :environ_key
   unless $options[:keyname]

--- a/lib/awsam/account.rb
+++ b/lib/awsam/account.rb
@@ -45,7 +45,15 @@ module Awsam
       end
     end
 
-    def print_environ
+    def print_unset_environ
+      Utils::bash_unset_environ(get_environ)
+    end
+
+    def print_environ(set_export)
+      Utils::bash_environ(get_environ, set_export)
+    end
+
+    def get_environ
       envs = {
         "AMAZON_ACCESS_KEY_ID"     => @params[:access_key],
         "AWS_ACCESS_KEY_ID"        => @params[:access_key],
@@ -60,8 +68,6 @@ module Awsam
 
         "EC2_URL"                  => ec2_url
       }
-
-      Utils::bash_environ(envs)
     end
 
     def find_key(name)

--- a/lib/awsam/utils.rb
+++ b/lib/awsam/utils.rb
@@ -9,10 +9,17 @@ module Awsam
       end
     end
 
-    # Print the appropriate environment variables set commands for bash
-    def self::bash_environ(envs)
+    # Unset each of the environ settings to clear the environ
+    def self.bash_unset_environ(envs)
       envs.each_pair do |k, v|
-        puts "export #{k}=\"#{v}\""
+        puts "unset #{k}"
+      end
+    end
+
+    # Print the appropriate environment variables set commands for bash
+    def self::bash_environ(envs, set_export = true)
+      envs.each_pair do |k, v|
+        puts "%s#{k}=\"#{v}\"" % [set_export ? "export " : ""]
       end
     end
 


### PR DESCRIPTION
No longer export the AWS environment variables in the current shell session. To export the environment to aws commands run the new shell wrapper `aenv` before executing commands like the EC2 CLI, awscli, etc. The awsam commands `assh` and `ascp` don't require any changes, as they will correctly load the environment as needed.

This is to protect against stuff like: https://iamakulov.com/notes/npm-malicious-packages/